### PR TITLE
Add git-based versioning and update command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/causeway/hooks/ping.sh
+++ b/causeway/hooks/ping.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
-# Ping causeway API for version check and telemetry
+# Ping causeway API for telemetry and check GitHub for updates
 # Uses only curl - no python required
 
 API_URL="https://causeway-api.fly.dev"
+GITHUB_API="https://api.github.com/repos/codimusmaximus/causeway/releases/latest"
 CAUSEWAY_DIR="$HOME/.causeway"
-VERSION="0.1.0"
 ID_FILE="$CAUSEWAY_DIR/.install_id"
+
+# Source version helper
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/version.sh"
+VERSION="$CAUSEWAY_VERSION"
 
 # Get or create install ID
 if [ -f "$ID_FILE" ]; then
@@ -19,20 +24,37 @@ fi
 PLATFORM=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m)
 
-# Ping API
-RESPONSE=$(curl -s -X POST "$API_URL/ping" \
+# Send telemetry to fly.dev (fire and forget)
+curl -s -X POST "$API_URL/ping" \
     -H "Content-Type: application/json" \
     -d "{\"install_id\":\"$INSTALL_ID\",\"version\":\"$VERSION\",\"platform\":\"$PLATFORM\",\"arch\":\"$ARCH\"}" \
     --connect-timeout 3 \
     --max-time 5 \
-    2>/dev/null)
+    >/dev/null 2>&1 &
 
-# Check for update (unless --silent)
-if [ "$1" != "--silent" ] && [ -n "$RESPONSE" ]; then
-    UPDATE=$(echo "$RESPONSE" | grep -o '"update_available":true')
-    if [ -n "$UPDATE" ]; then
-        LATEST=$(echo "$RESPONSE" | sed -n 's/.*"latest_version":"\([^"]*\)".*/\1/p')
-        # Output context for Claude to inform user about update
-        echo "[Causeway] Update available: v$LATEST. Please inform the user that a Causeway update is available and they can run 'causeway update' to install it."
+# Check for updates via GitHub API (unless --silent)
+if [ "$1" != "--silent" ]; then
+    GITHUB_RESPONSE=$(curl -s "$GITHUB_API" \
+        -H "Accept: application/vnd.github.v3+json" \
+        -H "User-Agent: causeway" \
+        --connect-timeout 3 \
+        --max-time 5 \
+        2>/dev/null)
+
+    if [ -n "$GITHUB_RESPONSE" ]; then
+        LATEST=$(echo "$GITHUB_RESPONSE" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')
+        if [ -n "$LATEST" ] && [ "$LATEST" != "$VERSION" ]; then
+            # Compare versions (strip 'v' prefix for comparison)
+            CURRENT_CLEAN="${VERSION#v}"
+            LATEST_CLEAN="${LATEST#v}"
+
+            # Remove any git describe suffix (e.g., -5-gabcdef)
+            CURRENT_CLEAN="${CURRENT_CLEAN%%-*}"
+
+            # Simple version comparison using sort -V
+            if [ "$(printf '%s\n' "$LATEST_CLEAN" "$CURRENT_CLEAN" | sort -V | tail -1)" = "$LATEST_CLEAN" ] && [ "$LATEST_CLEAN" != "$CURRENT_CLEAN" ]; then
+                echo "[Causeway] Update available: $LATEST → Run 'causeway update' to install"
+            fi
+        fi
     fi
 fi

--- a/causeway/hooks/version.sh
+++ b/causeway/hooks/version.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Bash helper for getting causeway version from git
+# Source this file to get CAUSEWAY_VERSION variable
+
+CAUSEWAY_DIR="${CAUSEWAY_DIR:-$HOME/.causeway}"
+
+# Get version from git describe, falling back to "unknown"
+CAUSEWAY_VERSION=$(cd "$CAUSEWAY_DIR" 2>/dev/null && git describe --tags --always 2>/dev/null || echo "unknown")
+
+export CAUSEWAY_VERSION

--- a/causeway/version.py
+++ b/causeway/version.py
@@ -1,0 +1,136 @@
+"""Version management for causeway."""
+import json
+import subprocess
+import urllib.request
+import urllib.error
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional
+
+GITHUB_API_URL = "https://api.github.com/repos/codimusmaximus/causeway/releases/latest"
+CAUSEWAY_ROOT = Path(__file__).parent.parent.resolve()
+
+
+@lru_cache(maxsize=1)
+def get_local_version() -> str:
+    """Get local version from git tags.
+
+    Returns tag (e.g., "v0.2.0"), tag with commits (e.g., "v0.2.0-5-gabcdef"),
+    commit hash, or "unknown" if not in a git repo.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "describe", "--tags", "--always"],
+            cwd=CAUSEWAY_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except Exception:
+        pass
+    return "unknown"
+
+
+def clear_version_cache():
+    """Clear the version cache after an update."""
+    get_local_version.cache_clear()
+
+
+def get_version_tuple(version_str: str) -> tuple:
+    """Parse version string to comparable tuple.
+
+    Handles:
+    - "v0.2.0" -> (0, 2, 0)
+    - "v0.2.0-5-gabcdef" -> (0, 2, 0)
+    - "0.2.0" -> (0, 2, 0)
+    - "abcdef" (commit hash) -> (0, 0, 0)
+    """
+    if version_str == "unknown":
+        return (0, 0, 0)
+
+    # Remove 'v' prefix if present
+    version = version_str.lstrip("v")
+
+    # Handle "v0.2.0-5-gabcdef" format - take only the version part
+    if "-" in version:
+        version = version.split("-")[0]
+
+    # Try to parse as semver
+    try:
+        parts = version.split(".")
+        return tuple(int(p) for p in parts[:3])
+    except (ValueError, IndexError):
+        # Probably a commit hash
+        return (0, 0, 0)
+
+
+def is_newer_version(latest: str, current: str) -> bool:
+    """Check if latest version is newer than current.
+
+    Compares major.minor.patch only.
+    """
+    latest_tuple = get_version_tuple(latest)
+    current_tuple = get_version_tuple(current)
+    return latest_tuple > current_tuple
+
+
+def is_on_edge() -> bool:
+    """Check if we're ahead of the latest tag (on edge/development).
+
+    Returns True if version is like "v0.2.0-5-gabcdef" (commits ahead of tag).
+    """
+    version = get_local_version()
+    if version == "unknown":
+        return False
+    # Check if there are commits after the tag (e.g., "v0.2.0-5-gabcdef")
+    return "-" in version and "g" in version.split("-")[-1]
+
+
+def fetch_latest_release() -> Optional[dict]:
+    """Fetch latest release info from GitHub API.
+
+    Returns dict with tag_name, name, html_url or None on failure.
+    """
+    try:
+        req = urllib.request.Request(
+            GITHUB_API_URL,
+            headers={
+                "Accept": "application/vnd.github.v3+json",
+                "User-Agent": "causeway",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return json.loads(resp.read().decode())
+    except Exception:
+        return None
+
+
+def check_for_updates() -> dict:
+    """Check for available updates.
+
+    Returns dict with:
+    - current_version: str
+    - latest_version: str or None
+    - update_available: bool
+    - on_edge: bool
+    - release_url: str or None
+    """
+    current = get_local_version()
+    result = {
+        "current_version": current,
+        "latest_version": None,
+        "update_available": False,
+        "on_edge": is_on_edge(),
+        "release_url": None,
+    }
+
+    release = fetch_latest_release()
+    if release:
+        latest = release.get("tag_name", "")
+        result["latest_version"] = latest
+        result["release_url"] = release.get("html_url")
+        result["update_available"] = is_newer_version(latest, current)
+
+    return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "causeway"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Rule enforcement and learning for Claude Code"
 requires-python = ">=3.10"
 dependencies = [
@@ -26,8 +26,11 @@ causeway-check = "causeway.hooks.check_rules:main"
 causeway-learn = "causeway.learning_agent:main"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "vcs"
 
 [tool.hatch.build.targets.wheel]
 packages = ["causeway"]


### PR DESCRIPTION
## Summary
- Replace hardcoded version strings with `git describe --tags --always` for dynamic versioning
- Move version checking from fly.dev API to GitHub Releases API
- Add `causeway update` command with `--edge` flag for updating to latest release or main branch
- Add GitHub Actions workflow to auto-create releases when tags are pushed


Closes #5