### PR TITLE
Simplify install script, add version command and colors

### DIFF
--- a/causeway/cli.py
+++ b/causeway/cli.py
@@ -581,12 +581,13 @@ def cmd_setup(reset: bool = False):
     if email:
         register_user(email, provider)
 
-    console.print(Panel.fit(
-        "[bold green]Configuration saved![/bold green]",
-        border_style="green"
-    ))
     console.print()
-    console.print("Run [cyan]causeway connect[/cyan] in your project directory to enable rules.")
+    console.print(Panel.fit(
+        "[bold green]Setup complete![/bold green]\n\n"
+        "Run [cyan]causeway connect[/cyan] in your project directory to enable rules.",
+        border_style="green",
+        padding=(1, 2)
+    ))
     console.print()
 
 
@@ -645,9 +646,9 @@ def main():
     usage = """causeway - rule enforcement for Claude Code
 
 Commands:
-    connect              Add hooks & MCP to Claude Code (run from your project)
-    setup                Reconfigure email, provider, and API key
+    setup                Configure email, provider, and API key
     setup --reset        Reset all configuration
+    connect              Add hooks & MCP to Claude Code (run from your project)
     config               Show current configuration
     config call-home     Show call-home telemetry status
     config call-home on  Enable call-home telemetry
@@ -658,6 +659,7 @@ Commands:
     rulesets             List available rulesets
     add <set>            Add a ruleset
     ui                   Start dashboard at localhost:8000
+    version              Show version information
 """
 
     if len(sys.argv) < 2:
@@ -693,6 +695,10 @@ Commands:
         cmd_list()
     elif cmd == "ui":
         cmd_ui()
+    elif cmd in ("version", "--version", "-v"):
+        sys.path.insert(0, str(CAUSEWAY_DIR))
+        from version import get_local_version
+        print(f"causeway {get_local_version()}")
     else:
         print(f"Unknown command: {cmd}")
         print(usage)

--- a/install.sh
+++ b/install.sh
@@ -4,32 +4,39 @@ set -e
 INSTALL_DIR="$HOME/.causeway"
 REPO="https://github.com/codimusmaximus/causeway.git"
 
-echo "Installing causeway..."
+# Colors
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+DIM='\033[2m'
+BOLD='\033[1m'
+NC='\033[0m' # No Color
+
+echo -e "${BOLD}Installing causeway...${NC}"
 
 # Always use uv - it handles platform detection correctly for native packages like sqlite-vec
 # (pip has issues installing the correct architecture on some systems)
 if command -v uv &> /dev/null; then
-    echo "Found uv"
+    echo -e "${DIM}Found uv${NC}"
 else
-    echo "Installing uv (recommended package manager)..."
+    echo -e "${DIM}Installing uv (recommended package manager)...${NC}"
     curl -LsSf https://astral.sh/uv/install.sh | sh
     export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
 fi
 
 # Clone or update
 if [ -d "$INSTALL_DIR" ]; then
-    echo "Updating..."
+    echo -e "${DIM}Updating...${NC}"
     cd "$INSTALL_DIR"
     git fetch --quiet
     git reset --hard origin/main --quiet
 else
-    echo "Downloading..."
+    echo -e "${DIM}Downloading...${NC}"
     git clone --quiet "$REPO" "$INSTALL_DIR"
     cd "$INSTALL_DIR"
 fi
 
 # Install dependencies
-echo "Installing dependencies..."
+echo -e "${DIM}Installing dependencies...${NC}"
 uv sync --quiet 2>/dev/null || uv sync
 
 # Create wrapper script for uv
@@ -48,11 +55,11 @@ if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
 fi
 
 echo ""
-echo "  ╔═══════════════════════════════════════╗"
-echo "  ║                                       ║"
-echo "  ║       Causeway installed!             ║"
-echo "  ║                                       ║"
-echo "  ╚═══════════════════════════════════════╝"
+echo -e "  ${GREEN}╔═══════════════════════════════════════╗${NC}"
+echo -e "  ${GREEN}║                                       ║${NC}"
+echo -e "  ${GREEN}║       ${BOLD}Causeway installed!${NC}${GREEN}             ║${NC}"
+echo -e "  ${GREEN}║                                       ║${NC}"
+echo -e "  ${GREEN}╚═══════════════════════════════════════╝${NC}"
 echo ""
-echo "  Run 'causeway setup' to configure your environment"
+echo -e "  Run ${CYAN}causeway setup${NC} to configure your environment"
 echo ""


### PR DESCRIPTION
## Summary
- Remove interactive telemetry prompt from install.sh (doesn't work with curl | bash)
- Install script now only installs dependencies and CLI, user runs `causeway setup` after
- Add `--help`, `-h`, `help` command support
- Add `version`, `--version`, `-v` command support
- Add colored output to install script (green box, cyan commands, dim progress)
- Improve setup completion message with instructions panel